### PR TITLE
Add detention history snapshots and trend chart

### DIFF
--- a/data/detentions.json
+++ b/data/detentions.json
@@ -4,5 +4,16 @@
   "no_criminal_conviction": 41589,
   "no_criminal_conviction_date": "September 7, 2025",
   "atd_monitored": 181401,
-  "atd_monitored_date": "September 6, 2025"
+  "atd_monitored_date": "September 6, 2025",
+  "history": [
+    {
+      "detention_total": 58766,
+      "detention_total_date": "September 7, 2025",
+      "no_criminal_conviction": 41589,
+      "no_criminal_conviction_date": "September 7, 2025",
+      "atd_monitored": 181401,
+      "atd_monitored_date": "September 6, 2025",
+      "captured_at": "2025-09-17T15:25:10.902835+00:00"
+    }
+  ]
 }

--- a/index.html
+++ b/index.html
@@ -11,8 +11,13 @@
     .count { font-size: 2.5rem; margin: 1.2rem 0; }
     button { background:#000; color:#fff; border:none; padding:0.6rem 1.2rem; font-size:1rem; cursor:pointer; }
     footer { margin-top:3rem; font-size:0.85rem; color:#666; }
+    .chart-card { margin-top: 2rem; padding: 1rem; border: 1px solid #eee; border-radius: 0.75rem; }
+    .chart-card h2 { margin-top: 0; }
+    #chart-placeholder { color: #666; font-size: 0.95rem; margin-top: 0.75rem; }
+    canvas { max-width: 100%; height: auto; display: block; }
   </style>
   <script async src="https://cdn.jsdelivr.net/npm/bsky-embed/dist/bsky-embed.es.js" type="module"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 </head>
 <body>
   <header>
@@ -49,6 +54,12 @@
   </script>
   -->
 
+  <section class="chart-card">
+    <h2>Detention Trend</h2>
+    <canvas id="detention-chart" height="180" role="img" aria-label="Line chart showing ICE detention totals over time"></canvas>
+    <div id="chart-placeholder">Historical trend data will appear after multiple snapshots are collected.</div>
+  </section>
+
   <section>
     <h2><a href="https://bsky.app/profile/did:plc:z4btti5mopfxgfbxe2ewgms7/feed/aaajtkdsnyd7a" target="_blank" rel="noopener" style="color: #1a0dab; text-decoration: underline;">ICE Watch Feed (Bluesky)</a></h2>
   </section>
@@ -63,6 +74,141 @@
   </footer>
 
   <script>
+    let detentionChart;
+
+    function scheduleTrend(history) {
+      if (typeof Chart !== 'undefined') {
+        renderTrend(history);
+        return;
+      }
+
+      const chartScript = document.querySelector('script[src*="chart.umd.min.js"]');
+      if (chartScript) {
+        chartScript.addEventListener('load', () => renderTrend(history), { once: true });
+      }
+    }
+
+    function renderTrend(history) {
+      const placeholder = document.getElementById('chart-placeholder');
+      const canvas = document.getElementById('detention-chart');
+      if (!canvas) {
+        return;
+      }
+
+      if (!Array.isArray(history) || history.length < 2 || typeof Chart === 'undefined') {
+        if (placeholder) {
+          placeholder.style.display = 'block';
+        }
+        if (detentionChart) {
+          detentionChart.destroy();
+          detentionChart = undefined;
+        }
+        return;
+      }
+
+      const cleaned = history
+        .filter(entry => entry && typeof entry.detention_total === 'number' && (entry.detention_total_date || entry.captured_at))
+        .map(entry => ({
+          date: entry.detention_total_date || entry.captured_at,
+          detention_total: entry.detention_total,
+          captured_at: entry.captured_at,
+        }));
+
+      const parseTime = item => {
+        const direct = Date.parse(item.date);
+        if (!Number.isNaN(direct)) {
+          return direct;
+        }
+        const fallback = item.captured_at ? Date.parse(item.captured_at) : NaN;
+        return Number.isNaN(fallback) ? 0 : fallback;
+      };
+
+      cleaned.sort((a, b) => parseTime(a) - parseTime(b));
+
+      const points = [];
+      cleaned.forEach(item => {
+        if (!points.length) {
+          points.push(item);
+          return;
+        }
+
+        const last = points[points.length - 1];
+        if (last.date === item.date && last.detention_total === item.detention_total) {
+          points[points.length - 1] = item;
+        } else {
+          points.push(item);
+        }
+      });
+
+      if (points.length < 2) {
+        if (placeholder) {
+          placeholder.style.display = 'block';
+        }
+        return;
+      }
+
+      const labels = points.map(point => {
+        const date = new Date(point.date);
+        if (!isNaN(date.getTime())) {
+          return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+        return point.date;
+      });
+      const dataPoints = points.map(point => point.detention_total);
+
+      if (placeholder) {
+        placeholder.style.display = 'none';
+      }
+
+      const ctx = canvas.getContext('2d');
+      if (detentionChart) {
+        detentionChart.data.labels = labels;
+        detentionChart.data.datasets[0].data = dataPoints;
+        detentionChart.update();
+        return;
+      }
+
+      detentionChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'People in ICE detention',
+              data: dataPoints,
+              fill: false,
+              tension: 0.25,
+              borderColor: '#0a63ff',
+              backgroundColor: 'rgba(10, 99, 255, 0.2)',
+              pointRadius: 3,
+              pointHoverRadius: 5,
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              display: false
+            },
+            tooltip: {
+              callbacks: {
+                label: context => `${context.parsed.y.toLocaleString()} people`
+              }
+            }
+          },
+          scales: {
+            y: {
+              ticks: {
+                callback: value => Number(value).toLocaleString()
+              }
+            }
+          }
+        }
+      });
+    }
+
     fetch('data/detentions.json')
       .then(r => r.json())
       .then(d => {
@@ -90,6 +236,8 @@
         } else {
           document.getElementById('metric-atd').textContent = '';
         }
+
+        scheduleTrend(d.history);
       })
       .catch(() => { document.getElementById('count').textContent = 'error'; });
   </script>

--- a/update_detentions.py
+++ b/update_detentions.py
@@ -1,78 +1,189 @@
-import requests
-from bs4 import BeautifulSoup
 import json
 import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
 
-url = "https://tracreports.org/immigration/quickfacts/"
-resp = requests.get(url)
-soup = BeautifulSoup(resp.text, "html.parser")
+import requests
+from bs4 import BeautifulSoup, Tag
 
-output = {}
+URL = "https://tracreports.org/immigration/quickfacts/"
+OUTPUT_PATH = Path("data/detentions.json")
+HISTORY_LIMIT = 365
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; ICE x Protocol scraper/1.0; +https://icexprotocol.com/)"
+}
 
-# 1. Total in ICE detention (first "font-bold text-5xl" number)
-all_bold_numbers = soup.find_all("div", class_="font-bold text-5xl")
-if all_bold_numbers and len(all_bold_numbers) > 0:
-    output["detention_total"] = int(all_bold_numbers[0].text.replace(",", "").strip())
-else:
-    output["detention_total"] = None
-
-# 2. Total in ICE detention date ("in detention on ...")
-dates = soup.find_all(string=lambda t: "in detention on" in t or "in ICE detention according to" in t)
-detention_date = None
-for d in dates:
-    nxt = d.find_next(string=True)
-    if nxt and "," in nxt:
-        detention_date = nxt.strip().replace(".", "")
-        break
-output["detention_total_date"] = detention_date
-
-
-# 3. No criminal conviction stats
-nocrim_number = None
-nocrim_date = None
-conviction_text_node = soup.find(string=lambda t: "no criminal conviction" in t.lower())
-if conviction_text_node:
-    # Work within the surrounding grid card for this fact
-    container = conviction_text_node.find_parent("div", class_="grid")
-    if container:
-        # Find the first numeric <strong> inside this card (that is NOT a percent)
-        for strong in container.find_all("strong"):
-            txt = strong.text.strip().replace(",", "")
-            if txt.isdigit():
-                nocrim_number = int(txt)
-                break
-        # Find a <strong> that looks like a date (e.g. June 15, 2025)
-        for strong in container.find_all("strong"):
-            if re.search(r"[A-Za-z]+\s+\d{1,2},\s+\d{4}", strong.text):
-                nocrim_date = strong.text.strip()
-                break
-
-output["no_criminal_conviction"] = nocrim_number
-output["no_criminal_conviction_date"] = nocrim_date
+DIGITS_ONLY_RE = re.compile(r"^\d[\d,]*$")
+NUMBER_WITH_COMMAS_RE = re.compile(r"\b\d{1,3}(?:,\d{3})+\b")
+LARGE_NUMBER_RE = re.compile(r"\b\d{4,}\b")
+DATE_RE = re.compile(r"[A-Za-z]+\s+\d{1,2},\s+\d{4}")
+MONTH_RE = re.compile(
+    r"(january|february|march|april|may|june|july|august|september|october|november|december)",
+    re.IGNORECASE,
+)
 
 
-# 4. ATD monitored stats
-atd_number = None
-atd_date = None
-atd_text_node = soup.find(string=lambda t: "alternatives to detention" in t.lower() and "monitoring" in t.lower())
-if atd_text_node:
-    container = atd_text_node.find_parent("div", class_="grid")
-    if container:
-        # Find a big bold number in this card
-        for bold in container.find_all("div", class_="font-bold text-5xl"):
-            num_txt = bold.text.replace(",", "").strip()
-            if num_txt.isdigit():
-                atd_number = int(num_txt)
-                break
-        # Pull the first date-looking string in the container
-        date_match = re.search(r"[A-Za-z]+\s+\d{1,2},\s+\d{4}", container.get_text())
-        if date_match:
-            atd_date = date_match.group(0)
+class ScraperError(RuntimeError):
+    """Raised when the TRAC facts page cannot be parsed."""
 
-output["atd_monitored"] = atd_number
-output["atd_monitored_date"] = atd_date
 
-with open("data/detentions.json", "w") as f:
-    json.dump(output, f, indent=2)
+def fetch_soup(url: str) -> BeautifulSoup:
+    response = requests.get(url, headers=HEADERS, timeout=20)
+    response.raise_for_status()
+    return BeautifulSoup(response.text, "html.parser")
 
-print(json.dumps(output, indent=2))
+
+def find_fact_card(soup: BeautifulSoup, fragment: str) -> Optional[Tag]:
+    anchor = soup.find(
+        "a",
+        href=lambda value: isinstance(value, str) and value.strip() == f"#{fragment}",
+    )
+    if not anchor:
+        return None
+
+    for ancestor in anchor.parents:
+        if getattr(ancestor, "name", None) != "div":
+            continue
+        if not ancestor.find("a", href=f"#{fragment}"):
+            continue
+        if ancestor.find(string=lambda s: isinstance(s, str) and "data current as of" in s.lower()):
+            return ancestor
+    return None
+
+
+def extract_primary_integer(card: Optional[Tag]) -> Optional[int]:
+    if card is None:
+        return None
+
+    for node in card.find_all(string=True):
+        text = node.strip()
+        if not text or "%" in text or any(ch.isalpha() for ch in text):
+            continue
+        if DIGITS_ONLY_RE.fullmatch(text):
+            return int(text.replace(",", ""))
+
+    text = card.get_text(" ", strip=True)
+
+    comma_match = NUMBER_WITH_COMMAS_RE.search(text)
+    if comma_match:
+        return int(comma_match.group(0).replace(",", ""))
+
+    for match in LARGE_NUMBER_RE.finditer(text):
+        candidate = match.group(0)
+        if _is_likely_year(text, match.start()):
+            continue
+        return int(candidate)
+
+    return None
+
+
+def extract_ratio_numerator(card: Optional[Tag]) -> Optional[int]:
+    if card is None:
+        return None
+    text = card.get_text(" ", strip=True)
+    match = re.search(r"([0-9][0-9,]*)\s+out of", text, re.IGNORECASE)
+    if match:
+        return int(match.group(1).replace(",", ""))
+    return extract_primary_integer(card)
+
+
+def extract_date(card: Optional[Tag]) -> Optional[str]:
+    if card is None:
+        return None
+    text = card.get_text(" ", strip=True)
+    match = DATE_RE.search(text)
+    if not match:
+        return None
+    date_text = match.group(0).replace(" ,", ",")
+    return date_text.strip().rstrip(".")
+
+
+def _is_likely_year(text: str, index: int) -> bool:
+    start = max(0, index - 25)
+    context = text[start:index].lower()
+    return bool(MONTH_RE.search(context))
+
+
+def load_existing_history() -> List[Dict[str, object]]:
+    if not OUTPUT_PATH.exists():
+        return []
+
+    try:
+        existing = json.loads(OUTPUT_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    history = existing.get("history", [])
+    if not isinstance(history, list):
+        return []
+
+    cleaned: List[Dict[str, object]] = []
+    for entry in history:
+        if isinstance(entry, dict) and "detention_total" in entry:
+            cleaned.append(entry)
+    return cleaned
+
+
+def snapshots_match(a: Dict[str, object], b: Dict[str, object]) -> bool:
+    keys = (
+        "detention_total",
+        "detention_total_date",
+        "no_criminal_conviction",
+        "no_criminal_conviction_date",
+        "atd_monitored",
+        "atd_monitored_date",
+    )
+    return all(a.get(key) == b.get(key) for key in keys)
+
+
+def append_snapshot(history: List[Dict[str, object]], snapshot: Dict[str, object]) -> List[Dict[str, object]]:
+    if history and snapshots_match(history[-1], snapshot):
+        history[-1]["captured_at"] = snapshot["captured_at"]
+        return history
+
+    history.append(snapshot)
+    if len(history) > HISTORY_LIMIT:
+        history = history[-HISTORY_LIMIT:]
+    return history
+
+
+def main() -> None:
+    soup = fetch_soup(URL)
+
+    total_card = find_fact_card(soup, "detention_held")
+    nocrim_card = find_fact_card(soup, "detention_nocrim")
+    atd_card = find_fact_card(soup, "detention_numatd")
+
+    if not total_card or not nocrim_card or not atd_card:
+        raise ScraperError("Could not locate one or more fact cards on the TRAC page")
+
+    output = {
+        "detention_total": extract_primary_integer(total_card),
+        "detention_total_date": extract_date(total_card),
+        "no_criminal_conviction": extract_ratio_numerator(nocrim_card),
+        "no_criminal_conviction_date": extract_date(nocrim_card),
+        "atd_monitored": extract_primary_integer(atd_card),
+        "atd_monitored_date": extract_date(atd_card),
+    }
+
+    missing = [key for key, value in output.items() if value is None]
+    if missing:
+        raise ScraperError(f"Missing values for: {', '.join(missing)}")
+
+    history = load_existing_history()
+    snapshot = {
+        **output,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+    }
+    history = append_snapshot(history, snapshot)
+
+    output_with_history = {**output, "history": history}
+
+    json_payload = json.dumps(output_with_history, indent=2)
+    OUTPUT_PATH.write_text(json_payload + "\n")
+    print(json_payload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- store a rolling history of detention snapshots alongside the latest totals when refreshing the TRAC scrape
- surface the history in the public dashboard with a Chart.js-powered trend card that gracefully waits for the library to load
- seed the data payload with the first captured snapshot so the chart can light up as more runs accumulate

## Testing
- python update_detentions.py
- python -m compileall update_detentions.py